### PR TITLE
Change icons from glyphicon to font-awesome icons

### DIFF
--- a/bootstrap3-datetimepicker-rails.gemspec
+++ b/bootstrap3-datetimepicker-rails.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
 
   spec.add_runtime_dependency 'momentjs-rails', '>= 2.8.1'
+  spec.add_runtime_dependency 'font-awesome-sass', '>= 4.5.0'
 end

--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -2381,15 +2381,15 @@
         disabledDates: false,
         enabledDates: false,
         icons: {
-            time: 'glyphicon glyphicon-time',
-            date: 'glyphicon glyphicon-calendar',
-            up: 'glyphicon glyphicon-chevron-up',
-            down: 'glyphicon glyphicon-chevron-down',
-            previous: 'glyphicon glyphicon-chevron-left',
-            next: 'glyphicon glyphicon-chevron-right',
-            today: 'glyphicon glyphicon-screenshot',
-            clear: 'glyphicon glyphicon-trash',
-            close: 'glyphicon glyphicon-remove'
+            time: 'fa fa-clock-o',
+            date: 'fa fa-calendar',
+            up: 'fa fa-chevron-up',
+            down: 'fa fa-chevron-down',
+            previous: 'fa fa-chevron-left',
+            next: 'fa fa-chevron-right',
+            today: 'fa fa-camera',
+            clear: 'fa fa-trash',
+            close: 'fa fa-times'
         },
         tooltips: {
             today: 'Go to today',


### PR DESCRIPTION
Bootstrap 4 drops support for `glyphicons`.
- Added `font-awesome` as a dependency
- Updated icon classes to `fa fa-icon_name`
